### PR TITLE
change nmap -> nnoremap for moving to parent dir

### DIFF
--- a/ftplugin/dirvish.vim
+++ b/ftplugin/dirvish.vim
@@ -1,6 +1,6 @@
 let s:nowait = (v:version > 703 ? '<nowait>' : '')
 execute 'nnoremap '.s:nowait.'<buffer><silent> q :doautocmd dirvish_buflocal BufDelete<CR>'
-nmap <buffer><silent> -     :Dirvish %:h:h<CR>
+nnoremap <buffer><silent> -     :Dirvish %:h:h<CR>
 nmap <buffer><silent> p     yy<c-w>p:e <c-r>=fnameescape(getreg('"',1,1)[0])<cr><cr>
 
 execute 'nnoremap '.s:nowait.'<buffer><silent> i    :<C-U>call dirvish#visit("edit", 0)<CR>'


### PR DESCRIPTION
I cannot move to the parent directory using '-' without this fix in Vim version 7.4.922 