### PR TITLE
Correctly handle shellslash when concealing paths

### DIFF
--- a/syntax/dirvish.vim
+++ b/syntax/dirvish.vim
@@ -2,7 +2,7 @@ if exists("b:current_syntax")
   finish
 endif
 
-let s:sep = (&shell =~? 'cmd.exe') ? '\\' : '\/'
+let s:sep = (exists('+shellslash') && &shellslash == 0) ? '\\' : '\/'
 
 exe 'syntax match DirvishPathHead ''\v.*'.s:sep.'\ze[^'.s:sep.']+'.s:sep.'?$'' conceal'
 exe 'syntax match DirvishPathTail ''\v[^'.s:sep.']+'.s:sep.'$'''


### PR DESCRIPTION
Use 'shellslash' in addition to 'shell' to determine separator
character. Now dirvish uses conceal to hide the directories in the
listing.

shellslash switches to unix-style slashes. It only exists on Windows and
evaluates to 0 on Linux (tested gvim 7.4.52 on Ubuntu). So while it
shouldn't break other platforms, we also can't solely rely on it to
determine what kind of slash to use.