### PR TITLE
Don't error leaving modified buffers with multiple windows

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -388,6 +388,7 @@ function! dirvish#open(...) range abort
     return
   endif
   if !&hidden && &modified
+      \ && (!exists("*win_findbuf") || len(win_findbuf(winbufnr(0))) == 1)
     call s:msg_error("E37: No write since last change")
     return
   endif


### PR DESCRIPTION
If a modified buffer has multiple windows, nothing will be lost when
navigating away from it with dirvish.  We can figure out how many there
are with `win_findbuf`.  (Worst case, if this is ever done wrong, Vim
will still raise the error itself.)

Fixes #47