### PR TITLE
Fix :Shdo E86: Buffer does not exist

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -89,8 +89,8 @@ function! dirvish#shdo(l1, l2, cmd)
   augroup dirvish_shcmd
     autocmd! * <buffer>
     " Refresh after executing the command.
-    exe 'autocmd ShellCmdPost <buffer> nested if bufexists('.dirvish_bufnr.')|buffer '.dirvish_bufnr
-          \ .'|silent! Dirvish %|endif|buffer '.bufnr('%').'|setlocal bufhidden=wipe'
+    exe 'autocmd ShellCmdPost <buffer> nested redraw!|if bufexists('.dirvish_bufnr.')|buffer '.dirvish_bufnr
+          \ .'|silent! Dirvish %|endif|close'
   augroup END
 
   if exists(':terminal')


### PR DESCRIPTION
Hello and thank you very much for this plugin!

I've encountered a few problems after using the `:Shdo` command, and they all seem to come from [these lines](https://github.com/justinmk/vim-dirvish/blob/1cc0c35c7203da2dd5294e37e55e144d106351bd/autoload/dirvish.vim#L92-L93) introduced in the latest [commit](https://github.com/justinmk/vim-dirvish/commit/1cc0c35c7203da2dd5294e37e55e144d106351bd):
```
    exe 'autocmd ShellCmdPost <buffer> nested if bufexists('.dirvish_bufnr.')|buffer '.dirvish_bufnr
\ .'|silent! Dirvish %|endif|buffer '.bufnr('%').'|setlocal bufhidden=wipe'
```
I didn't read the whole code of the plugin, so I could be wrong, but I suppose it tries to do 3 things:
- reload the dirvish buffer (if it exists):    `:Dirvish %`
- go back to the shell buffer:                 `:exe 'buffer '.bufnr('%')`
- prepare its deletion:                          `:setlocal bufhidden=wipe`

But on my system `:Shdo` causes 3 problems:
- it leaves the display corrupted (not sure this is the correct technical term, some parts of the screen are transparent);
I tried to fix it by prefixing the autocmd with `:redraw!`, to force the screen to be redrawn after the shell command has been executed.
- it leaves the window where the shell buffer was displayed open which makes 2 windows displaying a Dirvish buffer instead of one;
I tried to fix it by appending `:close` to the autocmd.
- it raises an error `E86` such as:
```
Error detected while processing ShellCmdPost Auto commands for "<buffer=6>":
E86: Buffer 6 does not exist
```
I tried to fix it by removing the part: `…|buffer '.bufnr('%').'|setlocal bufhidden=wipe'`

The purpose of this part seems to be to wipe the shell buffer.
But it fails, because when the autocmd is executed, the shell buffer doesn't exist anymore.
Here's an example of what's the autocmd is trying to do:

`if bufexists(5)|buffer 5|silent! Dirvish %|endif|buffer 6|setlocal bufhidden=wipe`

And here's an example of the buffers listing before `:Shdo` is executed:
```

1  a   "[No Name]"                    line 1
2u h   "/home/username/"              line 1
3u h   "/home/"                       line 1
4u h   "/"                            line 18
5u#a   "/tmp/"                        line 1
6 %a + "vM1REZp/0.sh"                 line 6
```

At this moment, the autocmd would succeed, because the buffer 6 exists.
But in the end, it fails, which means that something wipes the temp buffer after we execute `:Shdo`, but before the autocmd is executed.

I could be wrong, but maybe the problem comes from the fact that the shell buffer was already set to be wiped in [this line](https://github.com/justinmk/vim-dirvish/blob/1cc0c35c7203da2dd5294e37e55e144d106351bd/autoload/dirvish.vim#L81):

` setlocal bufhidden=wipe`

When I try to copy 3 files `foo`, `bar`, `baz` in my `/tmp` folder, with the command:
`:'<,'>Shdo cp {} {}.bak `

Here is what happens with the original autocmd:
http://imgur.com/a/dZT3u

And here is what happens with the new one:
http://imgur.com/a/PsFhu

In case it matters, I'm using linux, Vim [version 7.4](https://paste.debian.net/plain/893167) (with the patches 1-2156 included).
The only relevant part inside my vimrc concerning Dirvish is:
```
nmap <silent> -                           <Plug>(dirvish_split_up)<Plug>(my_dirvish_split)
nno <silent>  <Plug>(my_dirvish_split)    :let w:horizontal_split = 1<CR>

```
And in the filetype plugin Dirvish `~/.vim/after/ftplugin/dirvish.vim`:

```
nmap <silent> <buffer> h -
nmap <silent> <buffer> l <CR>

nmap <silent> <buffer>    q                           <Plug>(my_dirvish_quit)
nno  <silent> <buffer>    <Plug>(my_dirvish_quit)    :call <SID>quit()<CR>
fu! s:quit() abort
    if exists('w:horizontal_split')
        close
    else
        call feedkeys("\<Plug>(dirvish_quit)")
    endif
    return ''
endfu

nno <silent> <buffer> R  :<C-U>call <SID>reload()<CR>

if !exists('*s:reload')

    fu! s:reload() abort
        let search_line = getline('.')
        Dirvish %
        sil! call search('\V\^' . escape(search_line, '\') . '\$', 'cw')
    endfu

endif

nno <silent> <buffer> t :<C-U>call dirvish#open('tabedit', 1)<CR>
xno <silent> <buffer> t :call dirvish#open('tabedit', 1)<CR>

nno <silent> <buffer> zh :<C-U>call <SID>toggle_dot_entries()<CR>

if !exists('*s:toggle_dot_entries')

    fu! s:toggle_dot_entries() abort
        if !exists('b:hide_dot_entries')
            let b:hide_dot_entries = 1
        endif
        let b:hide_dot_entries = !b:hide_dot_entries

        if b:hide_dot_entries
            sil! keepp g:\v/\.[^\/]+/?$:d
            try
                norm! ``
            catch
            endtry

        else
            norm R
        endif
    endfu

endif

let b:dirvish['line'] = getline('.')

if get(b:, 'hide_dot_entries', 1)
    sil keepp g:\v/\.[^\/]+/?$:d_
endif

sort r /[^\/]$/

call search('\V\^'.escape(b:dirvish['line'],'\').'\$', 'cw')
```

Thank your for your time and your plugin!

