### PR TITLE
[RFC] Add preview mode (P)

### DIFF
--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -66,6 +66,8 @@ Buffer-local (filetype=dirvish) ~
     {Visual}.       Adds selected files to the local |arglist|.
     da.             Starts a new empty local |arglist|.
     x               Inserts "|:Shdo|  {}" into the command-line.
+    P               Toggle preview mode: the file under the cursor gets
+                    opened in the preview window.
 
 Buffer-local (:Shdo) ~
                                                                   *dirvish-Z!*

--- a/ftplugin/dirvish.vim
+++ b/ftplugin/dirvish.vim
@@ -17,6 +17,24 @@ endif
 
 nnoremap <buffer><silent> p   yy<c-w>p:e <c-r>=fnameescape(getreg('"',1,1)[0])<cr><cr>
 
+function! s:dirvish_preview()
+  exe 'pedit' expand('<cWORD>')
+endfunction
+function! s:dirvish_toggle_preview()
+  augroup dirvish_preview
+    au!
+    if get(b:, 'dirvish_preview', 0)
+      unlet b:dirvish_preview
+      pclose
+    else
+      let b:dirvish_preview = 1
+      au CursorMoved <buffer> call <SID>dirvish_preview()
+      call <SID>dirvish_preview()
+    endif
+  augroup END
+endfunction
+nnoremap <buffer><silent> P   :call <SID>dirvish_toggle_preview()<cr>
+
 execute 'nnoremap '.s:nowait.'<buffer><silent> i    :<C-U>.call dirvish#open("edit", 0)<CR>'
 execute 'nnoremap '.s:nowait.'<buffer><silent> <CR> :<C-U>.call dirvish#open("edit", 0)<CR>'
 execute 'nnoremap '.s:nowait.'<buffer><silent> a    :<C-U>.call dirvish#open("vsplit", 1)<CR>'


### PR DESCRIPTION
When examining a directory (e.g. `.git/rebase-apply`) it is useful to enable a mode where the file under the cursor gets displayed in the preview window: this way you can quickly look at the different files.

Maybe that should be a `<Plug>` mapping?  (https://github.com/justinmk/vim-dirvish/issues/21)