### PR TITLE
Fix Z! on windows again

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -117,7 +117,7 @@ function! dirvish#shdo(paths, cmd)
       \.'|buffer '.bufnr('%').'|setlocal bufhidden=wipe|endif'
   augroup END
 
-  nnoremap <buffer><silent> Z! :silent write<Bar>exe '!'.(has('win32')?'':shellescape(&shell).' %')<Bar>if !v:shell_error<Bar>close<Bar>endif<CR>
+  nnoremap <buffer><silent> Z! :silent write<Bar>exe '!'.(has('win32')?'':shellescape(&shell)).' %'<Bar>if !v:shell_error<Bar>close<Bar>endif<CR>
 endfunction
 
 function! s:buf_init() abort


### PR DESCRIPTION
Commit e1548de9dcfe3 make Z! exe empty string instead of '%' on windows.