### PR TITLE
version -> v:version

### DIFF
--- a/plugin/dirvish.vim
+++ b/plugin/dirvish.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_dirvish') || &cp || version < 700 || &cpo =~# 'C'
+if exists('g:loaded_dirvish') || &cp || v:version < 700 || &cpo =~# 'C'
   finish
 endif
 let g:loaded_dirvish = 1


### PR DESCRIPTION
Don't rely on compatability behaviour.

---

I'm not sure if there was a time where `version` did exist and `v:version` did not, but if so, it was pre-7.0 (~13 years).

Maybe checking for `v:version < 700` should be removed entirely. :>