### PR TITLE
fix s:sl()

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -14,7 +14,7 @@ endfunction
 
 " Normalize slashes for safe use of fnameescape(), isdirectory(). Vim bug #541.
 function! s:sl(path) abort
-  return tr(a:path, '\', '/')
+  return substitute(a:path, '\\\ze[^/]', '/', 'g')
 endfunction
 
 function! s:normalize_dir(dir) abort


### PR DESCRIPTION
because mkdir() can make a directory `call mkdir('a\/a','p')`