### PR TITLE
s:buf_init(): don't set autocmds multiple times

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -128,6 +128,7 @@ endfunction
 
 function! s:buf_init() abort
   augroup dirvish_buflocal
+    autocmd! * <buffer>
     autocmd BufEnter,WinEnter <buffer> call <SID>on_bufenter()
     autocmd TextChanged,TextChangedI <buffer> if <SID>buf_modified()
           \&& has('conceal')|exe 'setlocal conceallevel=0'|endif


### PR DESCRIPTION
```
If you would enter a directory and go back multiple times, both dirvish buffers
would set the same autocmds multiple times.
```