### PR TITLE
Add link to vim-dirvish-git plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Features
 - `:Shdo!` generates a shell script on the local [arglist](https://neovim.io/doc/user/editing.html#arglist)
 - Less code, fewer bugs (96% smaller than netrw)
 - Compatible with Vim 7.2+
+- Git support with [vim-dirvish-git](https://github.com/kristijanhusak/vim-dirvish-git) plugin
 
 Concepts
 --------


### PR DESCRIPTION
Hi,

I really like the simplicity of this plugin, but i missed some git support, like nerdtree has with [nerdtree-git-plugin](https://github.com/Xuyuanp/nerdtree-git-plugin). So I created a plugin that works for dirvish like [nerdtree-git-plugin](https://github.com/Xuyuanp/nerdtree-git-plugin) works for [NERDTree](https://github.com/scrooloose/nerdtree).

Here's the link. https://github.com/kristijanhusak/vim-dirvish-git

It still needs some polishing, but the main functionality is there.