### PR TITLE
`x` and `q` don't work with `$ git ls-files | vim +'setf dirvish' -`

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -63,7 +63,7 @@ function! s:list_dir(dir) abort
   endif
 endfunction
 
-function! s:set_args(args) abort
+function! dirvish#set_args(args) abort
   if exists('*arglistid') && arglistid() == 0
     arglocal
   endif
@@ -193,7 +193,7 @@ function! s:on_bufunload() abort
   call s:restore_winlocal_settings()
 endfunction
 
-function! s:buf_close() abort
+function! dirvish#buf_close() abort
   let d = get(w:, 'dirvish', {})
   if empty(d)
     return
@@ -450,7 +450,3 @@ function! dirvish#open(...) range abort
   call s:save_state(d)
   call s:open_dir(d, reloading)
 endfunction
-
-nnoremap <silent> <Plug>(dirvish_quit) :<C-U>call <SID>buf_close()<CR>
-nnoremap <silent> <Plug>(dirvish_arg) :<C-U>call <SID>set_args([getline('.')])<CR>
-xnoremap <silent> <Plug>(dirvish_arg) :<C-U>call <SID>set_args(getline("'<", "'>"))<CR>

--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -63,7 +63,7 @@ function! s:list_dir(dir) abort
   endif
 endfunction
 
-function! dirvish#set_args(args) abort
+function! s:set_args(args) abort
   if exists('*arglistid') && arglistid() == 0
     arglocal
   endif
@@ -193,7 +193,7 @@ function! s:on_bufunload() abort
   call s:restore_winlocal_settings()
 endfunction
 
-function! dirvish#buf_close() abort
+function! s:buf_close() abort
   let d = get(w:, 'dirvish', {})
   if empty(d)
     return
@@ -450,3 +450,7 @@ function! dirvish#open(...) range abort
   call s:save_state(d)
   call s:open_dir(d, reloading)
 endfunction
+
+nnoremap <silent> <Plug>(dirvish_quit) :<C-U>call <SID>buf_close()<CR>
+nnoremap <silent> <Plug>(dirvish_arg) :<C-U>call <SID>set_args([getline('.')])<CR>
+xnoremap <silent> <Plug>(dirvish_arg) :<C-U>call <SID>set_args(getline("'<", "'>"))<CR>

--- a/ftplugin/dirvish.vim
+++ b/ftplugin/dirvish.vim
@@ -12,9 +12,6 @@ if !hasmapto('<Plug>(dirvish_arg)', 'n')
   execute 'nmap '.s:nowait.'<buffer> x <Plug>(dirvish_arg)'
   execute 'xmap '.s:nowait.'<buffer> x <Plug>(dirvish_arg)'
 endif
-nnoremap <silent> <Plug>(dirvish_quit) :<C-U>call dirvish#buf_close()<CR>
-nnoremap <silent> <Plug>(dirvish_arg) :<C-U>call dirvish#set_args([getline('.')])<CR>
-xnoremap <silent> <Plug>(dirvish_arg) :<C-U>call dirvish#set_args(getline("'<", "'>"))<CR>
 
 nnoremap <buffer><silent> <Plug>(dirvish_up) :<C-U>exe "Dirvish %:h".repeat(":h",v:count1)<CR>
 nnoremap <buffer><silent> <Plug>(dirvish_split_up) :<C-U>exe 'split +Dirvish\ %:h'.repeat(':h',v:count1)<CR>
@@ -50,3 +47,6 @@ execute 'nnoremap '.s:nowait.'<buffer> !. :Shdo<CR>"_dd:write<CR>'
 " Buffer-local / and ? mappings to skip the concealed path fragment.
 nnoremap <buffer> / /\ze[^\/]*[\/]\=$<Home>
 nnoremap <buffer> ? ?\ze[^\/]*[\/]\=$<Home>
+
+" Force autoload if `ft=dirvish`
+if !exists('*dirvish#open')|try|call dirvish#open()|catch|endtry|endif

--- a/ftplugin/dirvish.vim
+++ b/ftplugin/dirvish.vim
@@ -12,6 +12,9 @@ if !hasmapto('<Plug>(dirvish_arg)', 'n')
   execute 'nmap '.s:nowait.'<buffer> x <Plug>(dirvish_arg)'
   execute 'xmap '.s:nowait.'<buffer> x <Plug>(dirvish_arg)'
 endif
+nnoremap <silent> <Plug>(dirvish_quit) :<C-U>call dirvish#buf_close()<CR>
+nnoremap <silent> <Plug>(dirvish_arg) :<C-U>call dirvish#set_args([getline('.')])<CR>
+xnoremap <silent> <Plug>(dirvish_arg) :<C-U>call dirvish#set_args(getline("'<", "'>"))<CR>
 
 nnoremap <buffer><silent> <Plug>(dirvish_up) :<C-U>exe "Dirvish %:h".repeat(":h",v:count1)<CR>
 nnoremap <buffer><silent> <Plug>(dirvish_split_up) :<C-U>exe 'split +Dirvish\ %:h'.repeat(':h',v:count1)<CR>


### PR DESCRIPTION
Here's a neat example given in the README of the project:

    git ls-files | vim +'setf dirvish' -

It works well, except for the `q` and `x` buffer-local mappings.
They don't work immediately because their `rhs` are `<plug>` mappings, which are are not defined in a `plugin/` directory, but in an `autoload/` one.

Consider this minimal `vimrc` written in `/tmp/vimrc`:

    set rtp^=~/.vim/plugged/vim-dirvish/
    set rtp+=~/.vim/plugged/vim-dirvish/after
    filetype plugin indent on

From the directory of `vim-dirvish`, if I start Vim like this:

    $ git ls-files | vim -Nu /tmp/vimrc +'setf dirvish' -

Vim opens a dirvish buffer listing the contents of the directory.
But if I press `x` on a filepath to add it to the arglist, nothing happens.

This PR tries to fix the issue by moving the `<plug>` mappings in the `plugin/` directory.

I think you moved the `<plug>` mappings in `autoload/` on purpose, because doing so allows you to make the `set_args()` and `buf_close()` functions local to the script. Thus, you avoid polluting the function namespace with two additional public functions which are not intended to be invoked directly by the user.

I value the reliability more than the reduced noise, but I understand your choice, because the mappings work correctly once you press another mapping whose `rhs` is defined in `plugin/` and which triggers the sourcing of the `autoload/` directory.
Still, pressing a key which sometimes work, but sometimes don't, is a little distracting because when it doesn't and you forgot the issue, you may lose time in a useless debugging or wondering whether you did something wrong.

Feel free to close the PR if you disagree.

---

Edit:

By the way, usually `dirvish` sets `'buftype'` to `nofile`, but not in the previous example.
So, when you press `Enter` on a file to edit it, you may get the error:

    dirvish: E37: No write since last change

Maybe it could be slightly improved by setting the option explicitly from the shell command-line:

    $ git ls-files | vim +'setf dirvish' +'setl bt=nofile' -
    #                                     ^^^^^^^^^^^^^^^^

---

Edit2:

There may be other settings which are not properly set in the previous example; namely `'swapfile'` and `'conceallevel'`.

It seems that usually, they are set by `s:buf_init()`, which is called by a chain of functions calls such as:

    dirvish#open() → s:open_dir() → s:buf_init()

Maybe `dirvish#open()` should be manually invoked from the shell (with a `+` argument) to handle the settings, but I don't know exactly how.

---

Edit3:

This shell command seems to fix all the issues:

    $ git ls-files | vim +'call dirvish#open("")' -

So, I close the PR.