### PR TITLE
Fix cosmetic/usability bug with marking paths.

### DIFF
--- a/syntax/dirvish.vim
+++ b/syntax/dirvish.vim
@@ -5,16 +5,18 @@ endif
 let s:sep = exists('+shellslash') && !&shellslash ? '\' : '/'
 let s:escape = 'substitute(escape(v:val, ".$~"), "*", ".*", "g")'
 
-" Define (again). Other windows may need the old definitions ...
-let s:pat = join(map(argv(), 'escape(fnamemodify(v:val[-1:]==#s:sep?v:val[:-2]:v:val, ":t"), "*.^$~\\")'), '\|')
-exe 'syntax match DirvishArg /\'.s:sep.'\@<=\%\('.s:pat.'\)\'.s:sep.'\?$/'
+exe 'syntax match DirvishPathHead =\v.*\'.s:sep.'\ze[^\'.s:sep.']+\'.s:sep.'?$= conceal'
+exe 'syntax match DirvishPathTail =\v[^\'.s:sep.']+\'.s:sep.'$='
+exe 'syntax match DirvishSuffix   =[^\'.s:sep.']*\%('.join(map(split(&suffixes, ','), s:escape), '\|') . '\)$='
+
+for p in argv()
+  let s:base = escape(fnamemodify(p[-1:] ==# s:sep ? p[:-2] : p, ":t"), "@*.^$~\\")
+  exe 'syntax match DirvishFullPath @^'.escape(p, "@*.^$~\\").'$@ contains=DirvishPathHead,DirvishArg'
+  exe 'syntax match DirvishArg @'.s:base.s:sep.'\?$@ contained'
+endfor
 
 if exists('b:current_syntax')
   finish
 endif
-
-exe 'syntax match DirvishPathHead =\v.*\'.s:sep.'\ze[^\'.s:sep.']+\'.s:sep.'?$= conceal'
-exe 'syntax match DirvishPathTail =\v[^\'.s:sep.']+\'.s:sep.'$='
-exe 'syntax match DirvishSuffix   =[^\'.s:sep.']*\%('.join(map(split(&suffixes, ','), s:escape), '\|') . '\)$='
 
 let b:current_syntax = "dirvish"

--- a/syntax/dirvish.vim
+++ b/syntax/dirvish.vim
@@ -5,6 +5,9 @@ endif
 let s:sep = exists('+shellslash') && !&shellslash ? '\' : '/'
 let s:escape = 'substitute(escape(v:val, ".$~"), "*", ".*", "g")'
 
+" Syntax rules for DirvishFullPath and DirvishArg must follow the other rules,
+" otherwise they may be overriden (see :h syn-priority).
+
 exe 'syntax match DirvishPathHead =\v.*\'.s:sep.'\ze[^\'.s:sep.']+\'.s:sep.'?$= conceal'
 exe 'syntax match DirvishPathTail =\v[^\'.s:sep.']+\'.s:sep.'$='
 exe 'syntax match DirvishSuffix   =[^\'.s:sep.']*\%('.join(map(split(&suffixes, ','), s:escape), '\|') . '\)$='

--- a/syntax/dirvish.vim
+++ b/syntax/dirvish.vim
@@ -10,9 +10,9 @@ exe 'syntax match DirvishPathTail =\v[^\'.s:sep.']+\'.s:sep.'$='
 exe 'syntax match DirvishSuffix   =[^\'.s:sep.']*\%('.join(map(split(&suffixes, ','), s:escape), '\|') . '\)$='
 
 " Define (again). Other windows may need the old definitions ...
-for p in argv()
-  let s:base = escape(fnamemodify(p[-1:] ==# s:sep ? p[:-2] : p, ":t"), "@*.^$~\\")
-  exe 'syntax match DirvishFullPath @^'.escape(p, "@*.^$~\\").'$@ contains=DirvishPathHead,DirvishArg'
+for s:p in argv()
+  let s:base = escape(fnamemodify(s:p[-1:] ==# s:sep ? s:p[:-2] : s:p, ":t"), "@*.^$~\\")
+  exe 'syntax match DirvishFullPath @^'.escape(s:p, "@*.^$~\\").'$@ contains=DirvishPathHead,DirvishArg'
   exe 'syntax match DirvishArg @'.s:base.s:sep.'\?$@ contained'
 endfor
 

--- a/syntax/dirvish.vim
+++ b/syntax/dirvish.vim
@@ -9,6 +9,7 @@ exe 'syntax match DirvishPathHead =\v.*\'.s:sep.'\ze[^\'.s:sep.']+\'.s:sep.'?$= 
 exe 'syntax match DirvishPathTail =\v[^\'.s:sep.']+\'.s:sep.'$='
 exe 'syntax match DirvishSuffix   =[^\'.s:sep.']*\%('.join(map(split(&suffixes, ','), s:escape), '\|') . '\)$='
 
+" Define (again). Other windows may need the old definitions ...
 for p in argv()
   let s:base = escape(fnamemodify(p[-1:] ==# s:sep ? p[:-2] : p, ":t"), "@*.^$~\\")
   exe 'syntax match DirvishFullPath @^'.escape(p, "@*.^$~\\").'$@ contains=DirvishPathHead,DirvishArg'


### PR DESCRIPTION
This commit addresses https://github.com/justinmk/vim-dirvish/issues/76
and more specifically, this comment: https://github.com/justinmk/vim-dirvish/issues/76#issuecomment-304442570.
It likely needs some cleanup, but it basically works.

A few notes:

- Syntax rules for DirvishFullPath and DirvishArg must follow the other
  rules, otherwise they may be overriden (see :h syn-priority).
- I am not sure whether \v has any effect in syntax rule, as the manual
  says that syntax patterns are always magic (:h syn-pattern).
- map() has been replaced by a for loop: this way the code is cleaner
  (IMO) and the resulting syntax rules shorter.
- I am not sure what the place for the condition testing for
  b:current_syntax is. That might need to be changed.