### PR TITLE
Don't signal E37 when 'autowriteall' is set

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -429,7 +429,7 @@ function! dirvish#open(...) range abort
     call s:msg_error("'autochdir' is not supported")
     return
   endif
-  if !&hidden && &modified
+  if !&autowriteall && !&hidden && &modified
       \ && (!exists("*win_findbuf") || len(win_findbuf(winbufnr(0))) == 1)
     call s:msg_error("E37: No write since last change")
     return


### PR DESCRIPTION
This is a trivial fix to avoid complaining and aborting on unsaved changes when `autowriteall` is set, since the changes will be saved automatically.