### PR TITLE
Shdo: Z!: Added compatibility with `git-bash` on Windows OS

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -136,7 +136,7 @@ function! dirvish#shdo(paths, cmd) abort
       \.'|buffer '.bufnr('%').'|setlocal bufhidden=wipe|endif'
   augroup END
 
-  nnoremap <buffer><silent> Z! :silent write<Bar>exe '!'.(has('win32')?'':shellescape(&shell)).' %'<Bar>if !v:shell_error<Bar>close<Bar>endif<CR>
+  nnoremap <buffer><silent> Z! :silent write<Bar>exe '!'.(has('win32')?fnameescape(escape(expand('%:p:gs?\\?/?'), '&\')):shellescape(&shell).' %')<Bar>if !v:shell_error<Bar>close<Bar>endif<CR>
 endfunction
 
 " Returns true if the buffer was modified by the user.


### PR DESCRIPTION
The PR is mainly aimed at users who want to generate and execute a bash script (`.sh`) on Windows OS, provided they have `&shell` set to `sh.exe`. This allows users to use `:[range]Shdo[!] {cmd}` with basic unix commands such as `mv`, `rm`, etc.; as well as avoiding a need to `set shellslash` which oftentimes breaks other plugins (e.g. `vim-fugitive`).

As for non `git-bash` users on Windows OS, the original workflow is preserved i.e. a batch (`.bat`) or powershell (`.ps1`) script will be generated and executed instead via `cmd.exe` or `powershell.exe`, respectively.

For example, to rename a list of visual-selected files on Windows OS:
```
:'<,'>Shdo mv {} {}
%TEMP%\XXXXXXX.tmp.sh
Z!
```
```
:'<,'>Shdo ren {} {}
%TEMP%\XXXXXXX.tmp.bat
Z!
```
```
:'<,'>Shdo rename-item {} {}
%TEMP%\XXXXXXX.tmp.ps1
Z!
```
I would greatly appreciate it to have your feedback on the changes. Cheers!