### PR TITLE
Fix icons do not work with directories on Windows

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -385,7 +385,7 @@ function! s:apply_icons() abort
       endif
     endfor
     if icon != ''
-      let isdir = (f[-1:] == '/')
+      let isdir = (f[-1:] == s:sep)
       let f = substitute(fnamemodify(f,':p'), escape(s:sep,'\').'$', '', 'g')  " Full path, trim slash.
       let head_esc = escape(fnamemodify(f,':h').(fnamemodify(f,':h')==s:sep?'':s:sep), '[,*.^$~\')
       let tail_esc = escape(fnamemodify(f, ':t').(isdir?(s:sep):''), '[,*.^$~\')


### PR DESCRIPTION
`s:apply_icons` determines the path is a directory or not by `f[-1:] == '/'`. On Windows, path separator is not '/' but '\\'. So icons are not shown for directories on Windows.