### PR TITLE
preserve window height when 'winminheight' is 0

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -318,7 +318,7 @@ endfunction
 
 " Performs `cmd` in all windows showing `bname`.
 function! s:bufwin_do(cmd, bname) abort
-  let [curtab, curwin, curwinalt] = [tabpagenr(), winnr(), winnr('#')]
+  let [curtab, curwin, curwinalt, origheight] = [tabpagenr(), winnr(), winnr('#'), winheight(0)]
   for tnr in range(1, tabpagenr('$'))
     let [origwin, origwinalt] = [tabpagewinnr(tnr), tabpagewinnr(tnr, '#')]
     for bnr in tabpagebuflist(tnr)
@@ -331,6 +331,7 @@ function! s:bufwin_do(cmd, bname) abort
   endfor
   exe s:noau 'tabnext '.curtab
   exe s:noau curwinalt.'wincmd w|' s:noau curwin.'wincmd w'
+  if &winminheight == 0 && (winheight(0) == origheight - 1) | exe s:noau 'resize +1' | endif
 endfunction
 
 function! s:buf_render(dir, lastpath) abort


### PR DESCRIPTION
Sometimes, the height of the window where `:Dirvish` is run changes:

    $ vim -Nu <(echo 'set wmh=0 rtp^=~/.vim/plugged/vim-dirvish') +'sp|wincmd _'
    :Dirvish

![gif](https://user-images.githubusercontent.com/8505073/67149959-fbd9d100-f2b1-11e9-9996-a1a9a3ca3d21.gif)

Notice how the height of the current window has decreased by 1, and how 1 line of the previous window is now visible while there was none before.

---

The issue comes from these lines:

https://github.com/justinmk/vim-dirvish/blob/fa6197150dbffe0f93028c46cd229bcca83105a9/autoload/dirvish.vim#L327
https://github.com/justinmk/vim-dirvish/blob/fa6197150dbffe0f93028c46cd229bcca83105a9/autoload/dirvish.vim#L333

They temporarily focus a different window, which may have the side-effect of changing the height of the current one. This only happens if you set `'winminheight'` to 0, in which case a non-focused window can be squashed to 0 lines. The reason why it happens is because when you focus a window, the cursor needs to be drawn somewhere, so the height of the window is reset to 1. From `:h 'wmh`:

> When set to zero, windows may be "squashed" to zero lines (i.e. just a
> status bar) if necessary.  They will return to at least one line when
> they become active (since the cursor has to have somewhere to go.)

`:noautocmd` can't prevent this.

---

The only fix I found is to save the original height of the window, then resize it if necessary:

    if &winminheight == 0 && (winheight(0) == origheight - 1) | exe s:noau 'resize +1' | endif

I don't think `&winminheight == 0` is necessary, but it helps understanding the purpose of the line.

You may wonder why not just restoring the height of the window like this:

    if &winminheight == 0 && (winheight(0) != origheight) | exe s:noau 'resize' origheight | endif

It seems to work, but I had a similar issue which I tried to fix with a similar command, and it didn't work as expected. When using the first version of the command, the fix did work exactly as expected.
So, in doubt, I used the first version here again.
Besides, I don't know much about the codebase, so the more restriction imposed upon the command, the less risk it creates another issue in some other corner case I didn't think about.

---

I don't know what is the purpose of the 2 lines mentioned at the top of the post. But if it is to restore the number of the previous window, and if it is necessary because the latter was changed while performing some action in another window, I think a better fix would be to perform this action via `win_execute()`. Unfortunately, it's rather new ([`8.1.1418`](https://github.com/vim/vim/commit/868b7b6712ea4f2232eeeae18c5cbbbddf2ee84d)) and unsupported in Nvim atm.
