### PR TITLE
preserve window height when 'winminheight' is 0 (follow-up)

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -306,33 +306,41 @@ function! s:try_visit(bnr, noau) abort
   return 0
 endfunction
 
-function! s:tab_win_do(tnr, cmd, bname) abort
-  exe s:noau 'tabnext' a:tnr
-  for wnr in range(1, tabpagewinnr(a:tnr, '$'))
-    if a:bname ==# bufname(winbufnr(wnr))
-      exe s:noau wnr.'wincmd w'
-      exe a:cmd
-    endif
-  endfor
-endfunction
-
-" Performs `cmd` in all windows showing `bname`.
-function! s:bufwin_do(cmd, bname) abort
-  let [curtab, curwin, curwinalt, origheight] = [tabpagenr(), winnr(), winnr('#'), winheight(0)]
-  for tnr in range(1, tabpagenr('$'))
-    let [origwin, origwinalt] = [tabpagewinnr(tnr), tabpagewinnr(tnr, '#')]
-    for bnr in tabpagebuflist(tnr)
-      if a:bname ==# bufname(bnr) " tab has at least 1 matching window
-        call s:tab_win_do(tnr, a:cmd, a:bname)
-        exe s:noau origwinalt.'wincmd w|' s:noau origwin.'wincmd w'
-        break
+if exists('*win_execute')
+  " Performs `cmd` in all windows showing `bname`.
+  function! s:bufwin_do(cmd, bname) abort
+    call map(filter(getwininfo(), {_,v -> a:bname ==# bufname(v.bufnr)}), {_,v -> win_execute(v.winid, s:noau.' '.a:cmd)})
+  endfunction
+else
+  function! s:tab_win_do(tnr, cmd, bname) abort
+    exe s:noau 'tabnext' a:tnr
+    for wnr in range(1, tabpagewinnr(a:tnr, '$'))
+      if a:bname ==# bufname(winbufnr(wnr))
+        exe s:noau wnr.'wincmd w'
+        exe a:cmd
       endif
     endfor
-  endfor
-  exe s:noau 'tabnext '.curtab
-  exe s:noau curwinalt.'wincmd w|' s:noau curwin.'wincmd w'
-  if &winminheight == 0 && (winheight(0) == origheight - 1) | exe s:noau 'resize +1' | endif
-endfunction
+  endfunction
+
+  function! s:bufwin_do(cmd, bname) abort
+    let [curtab, curwin, curwinalt, curheight, curwidth, winrestcmd] = [tabpagenr(), winnr(), winnr('#'), winheight(0), winwidth(0), winrestcmd()]
+    for tnr in range(1, tabpagenr('$'))
+      let [origwin, origwinalt] = [tabpagewinnr(tnr), tabpagewinnr(tnr, '#')]
+      for bnr in tabpagebuflist(tnr)
+        if a:bname ==# bufname(bnr)
+          call s:tab_win_do(tnr, a:cmd, a:bname)
+          exe s:noau origwinalt.'wincmd w|' s:noau origwin.'wincmd w'
+          break
+        endif
+      endfor
+    endfor
+    exe s:noau 'tabnext '.curtab
+    exe s:noau curwinalt.'wincmd w|' s:noau curwin.'wincmd w'
+    if (&winminheight == 0 && curheight != winheight(0)) || (&winminwidth == 0 && curwidth != winwidth(0))
+      exe s:noau winrestcmd
+    endif
+  endfunction
+endif
 
 function! s:buf_render(dir, lastpath) abort
   let bname = bufname('%')

--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -323,7 +323,7 @@ else
   endfunction
 
   function! s:bufwin_do(cmd, bname) abort
-    let [curtab, curwin, curwinalt, curheight, curwidth, winrestcmd] = [tabpagenr(), winnr(), winnr('#'), winheight(0), winwidth(0), winrestcmd()]
+    let [curtab, curwin, curwinalt, curheight, curwidth, squashcmds] = [tabpagenr(), winnr(), winnr('#'), winheight(0), winwidth(0), filter(split(winrestcmd(), '|'), 'v:val =~# " 0$"')]
     for tnr in range(1, tabpagenr('$'))
       let [origwin, origwinalt] = [tabpagewinnr(tnr), tabpagewinnr(tnr, '#')]
       for bnr in tabpagebuflist(tnr)
@@ -337,7 +337,12 @@ else
     exe s:noau 'tabnext '.curtab
     exe s:noau curwinalt.'wincmd w|' s:noau curwin.'wincmd w'
     if (&winminheight == 0 && curheight != winheight(0)) || (&winminwidth == 0 && curwidth != winwidth(0))
-      exe s:noau winrestcmd
+      for squashcmd in squashcmds
+        if squashcmd =~# '^\Cvert ' && winwidth(matchstr('\d\+', squashcmd)) != 0
+          \ || squashcmd =~# '^\d' && winheight(matchstr('\d\+', squashcmd)) != 0
+          exe s:noau squashcmd
+        endif
+      endfor
     endif
   endfunction
 endif


### PR DESCRIPTION
I'm sorry but the PR #149 I sent did not fix the reported issue entirely.

Here is another case where the height of the window is not preserved:

    $ vim -Nu <(cat <<'EOF'
    set wmh=0
    set rtp^=~/.vim/plugged/vim-dirvish
    au VimEnter * call Set_layout()
    fu Set_layout()
        bo sp
        helpg foobar
        close|copen
        wincmd p|1wincmd w|2wincmd w
        wincmd _
        call win_execute(win_getid(3), 'resize 10')
    endfu
    EOF
    )

From this layout, if `:Dirvish` is run, the height of the window decreases by `1`.

![gif](https://user-images.githubusercontent.com/8505073/67647754-ac3f7900-f933-11e9-8b02-3be5d786c76c.gif)

The issue disappears if `1wincmd w|2wincmd w` is removed; its purpose is to set the previous window. So I guess that the issue lies somewhere in the dirvish code which tries to preserve the number of the previous window.

It may seem as a contrived example, but I found it in a real usage scenario (using a plugin which automatically sets the height of entered windows).

The previous fix ran `:resize +1` to increase the size of the window by `1`; but this time, the lost line is above the window, not below. So, in this case, the right fix is `:1resize 0`.

Btw:

   - the fact that `:resize` accepts a window number as a prefix count is not documented (at least I could not find anything about it at `:h :resize`) Edit: It has just been documented [today](https://github.com/vim/vim/commit/1ff14ba24c4d85c008d7abe5e140dbb497ffea8d#diff-f95e9eafa950539fc4cd1e91223ca46c).

   - one can use `win_execute()` to run a command in a squashed window without increasing its height to 1 line (try `set wmh=0|bo sp|call win_execute(win_getid(1), 'set ft=python')`); so one could think that `set wmh=0|bo sp|call win_execute(win_getid(1), 'resize 0')` would work; it does not; Vim resizes the height of the first window to 1 line (so it seems that `win_execute()` needs 1 line to draw the cursor somewhere when it runs `:resize`, but not when it runs any other Ex command; no idea why this need is specific to `:resize`)

   - to fix the issue, one could be tempted to run `:1resize -1` instead of `:1resize 0`, but it does not work; I'm not even sure what `:resize` does when it receives a prefix count and a relative number as the suffix count; try this:

         $ vim -Nu NONE +'bo sp|wincmd _'
         :1resize -5
         :1resize -5

     Notice how the first `:1resize -5` makes the first window occupy the whole terminal minus 5 lines, and how the second `:1resize -5` squashes it again. That's not what `:resize -5` does in the current window.

All of this lead me to believe that `:resize` is unreliable/too complex to preserve the height of the dirvish window.

I think a simpler and more reliable way to preserve it, is to save the layout with `winrestcmd()`, then restore it with `:exe` at the end of `s:bufwin_do()`. Concretely, it would mean that this line:

https://github.com/justinmk/vim-dirvish/blob/79ffe5c6cf0a56d693659b6b98e92a82daf105f4/autoload/dirvish.vim#L321

would be replaced by:

    let [curtab, curwin, curwinalt, curheight, curwidth, winrestcmd] = [tabpagenr(), winnr(), winnr('#'), winheight(0), winwidth(0), winrestcmd()]

And this line:

https://github.com/justinmk/vim-dirvish/blob/79ffe5c6cf0a56d693659b6b98e92a82daf105f4/autoload/dirvish.vim#L334

by:

    if (&winminheight == 0 && curheight != winheight(0)) || (&winminwidth == 0 && curwidth != winwidth(0))
      exe s:noau winrestcmd
    endif

These two changes fix the issue reported in the PR #149 and the one reported at the top of this post.
They also fix the case of a window squashed vertically instead of horizontally (`'winminwidth'` set to `0`), which the previous PR didn't.

---

There are two other pitfalls, one can be fixed, but not the other one. However, this is only an issue if `s:bufwin_do()` runs a command which changes the windows layout.

I've looked at the code, and `s:bufwin_do()` is not used to change the windows layout, but to save and restore the view in a window. So I think the function is not affected, and I did not try to fix the pitfalls to not overcomplicate the code for no immediate gain. Although, I did document them in a [wrapper function](https://github.com/lacygoill/vim-lg-lib/blob/4fa9ed359603ed7eceffeff1d10f5c2e6166c203/autoload/lg.vim#L71-L198) I use to try to emulate `win_execute()` in Nvim.

Note that `win_execute()` is not affected by those pitfalls.

---

Also, since you said – in the PR #149 – that you were interested in using `win_execute()`, I thought it would be a good idea to give it a try.

Currently, `s:bufwin_do()` and `s:tab_win_do()` contain `23` lines of code. I think you could do without `s:tab_win_do()` and get the same result in only `1` line of code, using `win_execute()`:

    function! s:bufwin_do(cmd, bname) abort
      call map(filter(getwininfo(), {_,v -> a:bname ==# bufname(v.bufnr)}), {_,v -> win_execute(v.winid, s:noau.' '.a:cmd)})
    endfunction

Note that `getwininfo()` was added in [`7.4.1557`](https://github.com/vim/vim/releases/tag/v7.4.2204). As for lambda expressions, they were added in [`7.4.2044`](https://github.com/vim/vim/releases/tag/v7.4.2044). But these two versions are older than [`8.1.1418`](https://github.com/vim/vim/releases/tag/v8.1.1418) where `win_execute()` was added to Vim; so I think it's fair to assume that if someone has `win_execute()`, they also have `getwininfo()` and lambda expressions.

The refactoring is based on the old code of `s:bufwin_do()`: https://github.com/justinmk/vim-dirvish/commit/db33349b29250f4b31e172acd756ffe56db8fd38

Since then, the code has become more complex, but I think this complexity is not necessary when `win_execute()` is used. In particular, the previous command invoking `win_execute()` should only target windows whose buffer name is `a:bname`, so I don't think it could cause the screen to flicker or degrade the performance; although, I don't know how to test this properly.

---

I made sure that the PR fixes the two reported issues in Vim *and* in Nvim, but I haven't used it for very long (just a few days). So you may want to take your time before merging, in case you/I find other issues.

---

Whatever you don't like in the code, let me know and I will try to fix it.
