### PR TITLE
change legacy api: "fugitive#detect" to "FugitiveDetect"

### DIFF
--- a/plugin/dirvish.vim
+++ b/plugin/dirvish.vim
@@ -19,7 +19,7 @@ augroup dirvish_ftdetect
   autocmd BufEnter * if !exists('b:dirvish') && <SID>isdir(expand('%'))
     \ | exe 'Dirvish %'
     \ | elseif exists('b:dirvish') && &buflisted && bufnr('$') > 1 | setlocal nobuflisted | endif
-  autocmd FileType dirvish if exists('#fugitive') | call fugitive#detect(@%) | endif
+  autocmd FileType dirvish if exists('#fugitive') | call FugitiveDetect(@%) | endif
 augroup END
 
 nnoremap <silent> <Plug>(dirvish_up) :<C-U>exe 'Dirvish %:p'.repeat(':h',v:count1)<CR>


### PR DESCRIPTION
fix #160 
I didn't care about compability about old fugitive because FugitiveDetect() exists since 2 years ago
https://github.com/tpope/vim-fugitive/blame/b129752c07eea803356e77d263aedbd17cd19acd/plugin/fugitive.vim#L272