### PR TITLE
fix E95 when viewing directory matching CWD

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -417,7 +417,9 @@ function! s:open_dir(d, reload) abort
   " Try to find an existing buffer before creating a new one.
   let bnr = -1
   for pat in ['', ':~:.', ':~']
-    let bnr = bufnr('^'.fnamemodify(d._dir, pat).'$')
+    let dir = fnamemodify(d._dir, pat)
+    if dir == '' | continue | endif
+    let bnr = bufnr('^'.dir.'$')
     if -1 != bnr
       break
     endif


### PR DESCRIPTION
This PR tries to fix an issue where `E95` is raised when viewing a directory matching the CWD, and a hidden terminal buffer exists, as discussed in the issue #168.
