### PR TITLE
Don't normalize slashes outside Windows

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -15,7 +15,7 @@ endfunction
 
 " Normalize slashes for safe use of fnameescape(), isdirectory(). Vim bug #541.
 function! s:sl(path) abort
-  return tr(a:path, '\', '/')
+  return has('win32') ? tr(a:path, '\', '/') : a:path
 endfunction
 
 function! s:normalize_dir(dir, silent) abort


### PR DESCRIPTION
This PR prevents dirvish from translating backslashes into slashes outside Windows, to let the user open a file path containing a literal backslash.  This should fix the issue #173.
