### PR TITLE
Warn the user about autocmd changing the window on FileType

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -456,7 +456,9 @@ function! s:open_dir(d, reload) abort
     call s:buf_render(b:dirvish._dir, get(b:dirvish, 'lastpath', ''))
     " Set up Dirvish before any other `FileType dirvish` handler.
     exe 'source '.fnameescape(s:srcdir.'/ftplugin/dirvish.vim')
+    let curwin = winnr()
     setlocal filetype=dirvish
+    if curwin != winnr() | throw 'FileType autocmd changed the window' | endif
     let b:dirvish._c = b:changedtick
     call s:apply_icons()
   endif


### PR DESCRIPTION
If an autocmd changes the current window on FileType, it could raise unexpected errors.  Giving a warning could help the user to fix them.  Should fix issue #158.
