### PR TITLE
Get directory listing with globpath

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -42,21 +42,21 @@ function! s:parent_dir(dir) abort
 endfunction
 
 if v:version > 703
-function! s:globlist(pat) abort
-  return glob(a:pat, !s:suf(), 1)
+function! s:globlist(dir_esc, pat) abort
+  return globpath(a:dir_esc, a:pat, !s:suf(), 1)
 endfunction
 else "Vim 7.3 glob() cannot handle filenames containing newlines.
-function! s:globlist(pat) abort
-  return split(glob(a:pat, !s:suf()), "\n")
+function! s:globlist(dir_esc, pat) abort
+  return split(globpath(a:dir_esc, a:pat, !s:suf()), "\n")
 endfunction
 endif
 
 function! s:list_dir(dir) abort
-  " Escape for glob().
-  let dir_esc = escape(substitute(a:dir,'\[','[[]','g'),'{}^$\')
-  let paths = s:globlist(dir_esc.'*')
-  "Append dot-prefixed files. glob() cannot do both in 1 pass.
-  let paths = paths + s:globlist(dir_esc.'.[^.]*')
+  " Escape for globpath().
+  let dir_esc = escape(substitute(a:dir,'\[','[[]','g'), ',{}^$\')
+  let paths = s:globlist(dir_esc, '*')
+  "Append dot-prefixed files. globpath() cannot do both in 1 pass.
+  let paths = paths + s:globlist(dir_esc, '.[^.]*')
 
   if get(g:, 'dirvish_relative_paths', 0)
       \ && a:dir != s:parent_dir(getcwd()) "avoid blank CWD

--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -53,7 +53,7 @@ endif
 
 function! s:list_dir(dir) abort
   " Escape for globpath().
-  let dir_esc = escape(substitute(a:dir,'\[','[[]','g'), ',{}^$\')
+  let dir_esc = escape(substitute(a:dir,'\[','[[]','g'), ',;*?{}^$\')
   let paths = s:globlist(dir_esc, '*')
   "Append dot-prefixed files. globpath() cannot do both in 1 pass.
   let paths = paths + s:globlist(dir_esc, '.[^.]*')


### PR DESCRIPTION
Fix dirvish for auto-mounted paths where mount root does not glob.

Problem: vim `glob()` does not match in subdirectories of some auto mounted paths, for example,
in `/home/autouser/docs/`.  This is probably because `autouser` does not glob in `/home/`.

Solution: use `globpath` instead of `glob` to do glob expansion only in leaf directory.