### PR TITLE
fix: Pattern delimiter not found

### DIFF
--- a/syntax/dirvish.vim
+++ b/syntax/dirvish.vim
@@ -2,14 +2,13 @@ if 'dirvish' !=# get(b:, 'current_syntax', 'dirvish')
   finish
 endif
 
-let s:sep = exists('+shellslash') && !&shellslash ? '\' : '/'
-let s:sep_esc = s:sep == '\' ? '\\' : '/'
+let s:sep = escape(exists('+shellslash') && !&shellslash ? '\' : '/', '\\')
 let s:escape = 'substitute(escape(v:val, ".$~"), "*", ".*", "g")'
 
 " Define once (per buffer).
 if !exists('b:current_syntax')
-  exe 'syntax match DirvishPathHead =.*'.s:sep_esc.'\ze[^'.s:sep.']\+'.s:sep_esc.'\?$= conceal'
-  exe 'syntax match DirvishPathTail =[^'.s:sep.']\+'.s:sep_esc.'$='
+  exe 'syntax match DirvishPathHead =.*'.s:sep.'\ze[^'.s:sep.']\+'.s:sep.'\?$= conceal'
+  exe 'syntax match DirvishPathTail =[^'.s:sep.']\+'.s:sep.'$='
   exe 'syntax match DirvishSuffix   =[^'.s:sep.']*\%('.join(map(split(&suffixes, ','), s:escape), '\|') . '\)$='
 endif
 

--- a/syntax/dirvish.vim
+++ b/syntax/dirvish.vim
@@ -2,7 +2,7 @@ if 'dirvish' !=# get(b:, 'current_syntax', 'dirvish')
   finish
 endif
 
-let s:sep = escape(exists('+shellslash') && !&shellslash ? '\' : '/', '\\')
+let s:sep = exists('+shellslash') && !&shellslash ? '\\' : '/'
 let s:escape = 'substitute(escape(v:val, ".$~"), "*", ".*", "g")'
 
 " Define once (per buffer).


### PR DESCRIPTION
For windows backslash should be escaped in [^\].

Fixes #192