### PR TITLE
Do not update alternate buffer on opening directory

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -426,7 +426,7 @@ function! s:open_dir(d, reload) abort
   endfor
 
   if -1 == bnr
-    execute 'silent' s:noswapfile 'edit' fnameescape(d._dir)
+    execute 'silent' s:noswapfile 'keepalt edit' fnameescape(d._dir)
   else
     execute 'silent' s:noswapfile 'buffer' bnr
   endif


### PR DESCRIPTION
Fixes #183 

I confirmed this fix with the following steps:

1. Open Vim or Neovim
2. `:e file-a.txt`
3. `:e file-b.txt`
4. `:Dirvish`
5. Type `gq`
6. Type `<C-^>`
7. Confirm the current buffer was switched to file-a.txt