### PR TITLE
feat: emit DirvishShdo event

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -5,6 +5,11 @@ let s:noau       = 'silent noautocmd keepjumps'
 let s:cb_map = {}   " callback map
 let s:rel = get(g:, 'dirvish_relative_paths', 0)
 
+augroup dirvish_dummy_events
+  autocmd!
+  autocmd User Dirvish* "
+augroup END
+
 " Debug:
 "     echo '' > dirvish.log ; tail -F dirvish.log
 "     nvim +"let g:dirvish_dbg=1" -- b1 b2
@@ -171,6 +176,9 @@ func! dirvish#shdo(paths, cmd) abort
   augroup END
 
   nnoremap <buffer><silent> Z! :silent write<Bar>exe '!'.(has('win32')?fnameescape(escape(expand('%:p:gs?\\?/?'), '&\')):join(map(split(&shell), 'shellescape(v:val)')).' %')<Bar>if !v:shell_error<Bar>close<Bar>endif<CR>
+
+  let b:dirvish_dir = escape(shellescape(head),'&\')
+  doautocmd <nomodeline> User DirvishShdoCreated
 endf
 
 " Returns true if the buffer was modified by the user.

--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -127,6 +127,28 @@ dirvish#remove_icon_fn(fn_id)
     |dirvish#add_icon_fn()|.
 
 ==============================================================================
+AUTOCOMMANDS                                            *dirvish-autocommands*
+
+DirvishShdoCreated                                   *User_DirvishShdoCreated*
+    A |User| |autocommand| invoked after creating a |:Shdo| buffer.
+    b:dirvish_dir is set to the previous Dirvish buffer's path.
+
+    To ensure scripts always cd to the current dirvish directory, you could
+    add this to your vimrc: >
+
+    autocmd User DirvishShdoCreated call OnShdoCreated()
+    function! OnShdoCreated() abort
+        if has('win32')
+            " work across hard drives
+            let chdir = 'pushd '
+        else
+            let chdir = 'cd '
+        endif
+        call append(0, [chdir .. b:dirvish_dir, ''])
+    endf
+<
+
+==============================================================================
 OPTIONS                                                      *dirvish-options*
 
 g:dirvish_mode = 1                                  *g:dirvish_mode*

--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -129,7 +129,7 @@ dirvish#remove_icon_fn(fn_id)
 ==============================================================================
 AUTOCOMMANDS                                            *dirvish-autocommands*
 
-DirvishShdoCreated                                   *User_DirvishShdoCreated*
+DirvishShdo                                   *User_DirvishShdo*
     A |User| |autocommand| invoked after creating a |:Shdo| buffer.
     b:dirvish_dir is set to the previous Dirvish buffer's path.
 


### PR DESCRIPTION
I want all of my scripts to explicitly start in the current dirvish working
directory, so I use the example from the doc:
  let g:dirvish_shdo_preamble = 'cd {}'

Other users may tend to create scripts with arguments, want their
commands to be inside a function, or output some diagnostic data.

Using the same escaping that is applied on lines since that seems like
the safest thing to do.