### PR TITLE
use full path instead of relative path when opening a directory

### DIFF
--- a/plugin/dirvish.vim
+++ b/plugin/dirvish.vim
@@ -16,8 +16,8 @@ augroup dirvish
   " Remove netrw and NERDTree directory handlers.
   autocmd VimEnter * if exists('#FileExplorer') | exe 'au! FileExplorer *' | endif
   autocmd VimEnter * if exists('#NERDTreeHijackNetrw') | exe 'au! NERDTreeHijackNetrw *' | endif
-  autocmd BufEnter * if !exists('b:dirvish') && <SID>isdir(expand('%'))
-    \ | exe 'Dirvish %'
+  autocmd BufEnter * if !exists('b:dirvish') && <SID>isdir(expand('%:p'))
+    \ | exe 'Dirvish %:p'
     \ | elseif exists('b:dirvish') && &buflisted && bufnr('$') > 1 | setlocal nobuflisted | endif
   autocmd FileType dirvish if exists('#fugitive') | call FugitiveDetect(@%) | endif
   autocmd ShellCmdPost * if exists('b:dirvish') | exe 'Dirvish %' | endif


### PR DESCRIPTION
On Windows,
When the dirvish buffer for a directory does not exist yet,
an empty string is passed to `s:isdir` and as a result, the dirvish buffer is empty and it is necessary to type `-` from that buffer to get the expected buffer content.

I noticed that using full paths instead of a relative path addressed the issue.