### PR TITLE
Fixes 'tree view' mapping suggestion in doc to not change file order, and not overwrite " register

### DIFF
--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -242,7 +242,7 @@ There is a hacky solution. Put this in your vimrc and hit "t" on a directory: >
     augroup dirvish_config
       autocmd!
       autocmd FileType dirvish
-                  \ nnoremap <silent><buffer> t ddO<Esc>:let @"=substitute(@", '\n', '', 'g')<CR>:r ! find "<C-R>"" -maxdepth 1 -print0 \| xargs -0 ls -Fd<CR>:silent! keeppatterns %s/\/\//\//g<CR>:silent! keeppatterns %s/[^a-zA-Z0-9\/]$//g<CR>:silent! keeppatterns g/^$/d<CR>:noh<CR>
+                  \ nnoremap <silent><buffer> t 0C<Esc>:let @"=substitute(@", '\n', '', 'g')<CR>:r ! find "<C-R>"" -maxdepth 1 -print0 \| xargs -0 ls -Fd<CR>:silent! keeppatterns %s/\/\//\//g<CR>:silent! keeppatterns %s/[^a-zA-Z0-9\/]$//g<CR>:silent! keeppatterns g/^$/d<CR>:noh<CR>
     augroup END
 
 Note:

--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -242,12 +242,11 @@ There is a hacky solution. Put this in your vimrc and hit "t" on a directory: >
     augroup dirvish_config
       autocmd!
       autocmd FileType dirvish
-                  \ nnoremap <silent><buffer> t 0C<Esc>:let @"=substitute(@", '\n', '', 'g')<CR>:r ! find "<C-R>"" -maxdepth 1 -print0 \| xargs -0 ls -Fd<CR>:silent! keeppatterns %s/\/\//\//g<CR>:silent! keeppatterns %s/[^a-zA-Z0-9\/]$//g<CR>:silent! keeppatterns g/^$/d<CR>:noh<CR>
+                  \ nnoremap <silent><buffer> t :let b:dirvish_old_default_reg = @"<CR>0C<Esc>:let @"=substitute(@", '\n', '', 'g')<CR>:r ! find "<C-R>"" -maxdepth 1 -print0 \| xargs -0 ls -Fd<CR>:silent! keeppatterns %s/\/\//\//g<CR>:silent! keeppatterns %s/[^a-zA-Z0-9\/]$//g<CR>:silent! keeppatterns g/^$/d<CR>:noh<CR>:let @"=b:dirvish_old_default_reg<CR>:unlet b:dirvish_old_default_reg<CR>
     augroup END
 
 Note:
 - Expects unix-style filepaths.
-- Will overwrite your " register.
 
 ==============================================================================
  vim:tw=78:ts=4:et:ft=help:norl:


### PR DESCRIPTION
Not to suggest that maintaining a hacky workaround is the best use of anyone's time, but might as well have a _correct_ hacky workaround ¯\\_ (ツ)_/¯. 

This PR is in regard to the `t` remap suggested in the docs, which allows subdirectories to be included in the file listing (making it sort of a tree-style view).

This PR has two commits, the first change prevents the file order from being messed with. The second saves your `"` register so that it's not overwritten.

**Before:**
<img alt="before behaviour" src="https://github.com/justinmk/vim-dirvish/assets/4468354/778aa234-0784-470f-b8e9-e793cff1812e" height="400" />

**After:**
<img alt="after behaviour" src="https://github.com/justinmk/vim-dirvish/assets/4468354/2e7e71e3-1387-4949-ac29-fe01921000e2" height="400" />
