### PR TITLE
fix(apply_icons): filename may be truncated

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -435,7 +435,7 @@ func! s:apply_icons() abort
       let isdir = (f[-1:] == s:sep)
       let f = substitute(s:f(f), escape(s:sep,'\').'$', '', 'g')  " Full path, trim slash.
       let tail_esc = escape(fnamemodify(f,':t').(isdir?(s:sep):''), '[,*.^$~\')
-      exe 'syntax match DirvishColumnHead =\%' . i . 'l^.\{-}\ze'.tail_esc.'$= conceal cchar='.icon
+      exe 'syntax match DirvishColumnHead =\%'.i.'l^.\{-}\ze'.tail_esc.'$= conceal cchar='.icon
     endif
   endfor
 endf

--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -421,7 +421,9 @@ func! s:apply_icons() abort
     return
   endif
   highlight clear Conceal
+  let i = 0
   for f in getline(1, '$')
+    let i += 1
     let icon = ''
     for id in sort(keys(s:cb_map))
       let icon = s:cb_map[id](f)
@@ -433,7 +435,7 @@ func! s:apply_icons() abort
       let isdir = (f[-1:] == s:sep)
       let f = substitute(s:f(f), escape(s:sep,'\').'$', '', 'g')  " Full path, trim slash.
       let tail_esc = escape(fnamemodify(f,':t').(isdir?(s:sep):''), '[,*.^$~\')
-      exe 'syntax match DirvishColumnHead =^.\{-}\ze'.tail_esc.'$= conceal cchar='.icon
+      exe 'syntax match DirvishColumnHead =\%' . i . 'l^.\{-}\ze'.tail_esc.'$= conceal cchar='.icon
     endif
   endfor
 endf


### PR DESCRIPTION
Version: Neovim v0.9.4 and Vim 9.0 running on Linux and Windows

I am a long-time dirvish user, but only recently started using the dirvish#add_icon_fn() to add devicons to the dirvish display.  However, I found that occasionally the filenames displayed by dirvish are truncated from the left when the icons are being applied.

To see the issue, create files 'abc-file.txt', 'defg-file.txt', and 'file.txt' in a directory and display them in a dirvish buffer.  All filenames display as 'file.txt' as shown below.

![image](https://github.com/justinmk/vim-dirvish/assets/4481175/52f5f0b3-dd62-4b6b-a114-e3b6efc012f4)

This Neovim screenshot was taken on a Windows workstation, but the same behavior can be seen in Neovim and Vim on both Linux and Windows machines.

The problem seems to occur when the base name of one of the files in the directory matches the right-hand portion of one or more other filenames in the same directory.  However, experimentation shows that it does not always happen in this case, so there must be more specific conditions contributing to it.

After some debugging, I found that the cause is in the syntax matching performed by the s:apply_icons() function in autoload/dirvish.vim.  I am new to vim syntax matching, but believe that the problem is caused by the iteration of the match operation across all the files in the directory.  When the common match pattern encounters multiple files whose names end in the same characters, it 'swallows up' the leading characters of the names that do not match, leaving identical filename suffixes shown in the dirvish display.

To fix it, I inserted a line counter into the match pattern inside the loop that iterates through the file list, forcing a unique pattern to be matched against each file.  This fix has worked fine on my machines for several weeks now.
