### PR TITLE
fix(mappings): visual mode commands only operate on a single selected file

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -534,7 +534,9 @@ func! dirvish#open(...) range abort
   endif
 
   if a:0 > 1
-    call s:open_selected(a:1, a:2, a:firstline, a:lastline)
+    " Detect whether a <Cmd> mapping or the legacy fallback is being used
+    let l:visual_lines = mode(0) == 'n' ? [a:firstline, a:lastline] : [line('v'), line('.')]
+    call s:open_selected(a:1, a:2, min(l:visual_lines), max(l:visual_lines))
     return
   endif
 


### PR DESCRIPTION
Problem:
`{Visual}O` and similar commands only operate on a single file after 6233243 (fix(mappings): prefer `<cmd>`, drop `<silent>` #235, 2022-12-08).

Solution:
Use `line('v')` and `line('.')` to get the visual range when the `<Cmd>` mappings are used.