### PR TITLE
docs: more extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Extensions
 Some people have created plugins that extend Dirvish:
 
 - [remote-viewer](https://github.com/bounceme/remote-viewer) - Browse `ssh://` and other remote paths
-- [vim-dirvish-git.lua](https://github.com/brianhuster/vim-dirvish-git.lua) - Show git status of each file
+- [dirvish-git.nvim](https://github.com/brianhuster/dirvish-git.nvim) - Show git status of each file
 - [vim-dirvish-git](https://github.com/kristijanhusak/vim-dirvish-git) - Show git status of each file 
 - [vim-dirvinist](https://github.com/fsharpasharp/vim-dirvinist) - List files defined by projections
-- [dirvish-do.nvim](https://github.com/brianhuster/dirvish-do.nvim) - Add key mappings for file manipulation
+- [dirvish-do.nvim](https://github.com/brianhuster/dirvish-do.nvim) - Add file manipulation keybindings
 - [vim-dirvish-dovish](https://github.com/roginfarrer/vim-dirvish-dovish) - Add vim-style file manipulation commands
 
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Extensions
 Some people have created plugins that extend Dirvish:
 
 - [remote-viewer](https://github.com/bounceme/remote-viewer) - Browse `ssh://` and other remote paths
-- [vim-dirvish-git](https://github.com/kristijanhusak/vim-dirvish-git) - Show git status of each file
+- [vim-dirvish-git](https://github.com/kristijanhusak/vim-dirvish-git) and [vim-dirvish-git.lua](https://github.com/brianhuster/vim-dirvish-git.lua) - Show git status of each file
 - [vim-dirvinist](https://github.com/fsharpasharp/vim-dirvinist) - List files defined by projections
 - [vim-dirvish-dovish](https://github.com/roginfarrer/vim-dirvish-dovish) - Add vim-style file manipulation commands
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Extensions
 Some people have created plugins that extend Dirvish:
 
 - [remote-viewer](https://github.com/bounceme/remote-viewer) - Browse `ssh://` and other remote paths
-- [vim-dirvish-git](https://github.com/kristijanhusak/vim-dirvish-git) and [vim-dirvish-git.lua](https://github.com/brianhuster/vim-dirvish-git.lua) - Show git status of each file
+- [vim-dirvish-git.lua](https://github.com/brianhuster/vim-dirvish-git.lua) - Show git status of each file
+- [vim-dirvish-git](https://github.com/kristijanhusak/vim-dirvish-git) - Show git status of each file 
 - [vim-dirvinist](https://github.com/fsharpasharp/vim-dirvinist) - List files defined by projections
 - [vim-dirvish-dovish](https://github.com/roginfarrer/vim-dirvish-dovish) - Add vim-style file manipulation commands
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Some people have created plugins that extend Dirvish:
 - [vim-dirvish-git.lua](https://github.com/brianhuster/vim-dirvish-git.lua) - Show git status of each file
 - [vim-dirvish-git](https://github.com/kristijanhusak/vim-dirvish-git) - Show git status of each file 
 - [vim-dirvinist](https://github.com/fsharpasharp/vim-dirvinist) - List files defined by projections
+- [dirvish-do.nvim](https://github.com/brianhuster/dirvish-do.nvim) - Add key mappings for file manipulation
 - [vim-dirvish-dovish](https://github.com/roginfarrer/vim-dirvish-dovish) - Add vim-style file manipulation commands
 
 

--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -422,7 +422,7 @@ func! s:buf_render(dir, lastpath) abort
   endif
 endf
 
-func! dirvish#apply_icons() abort
+func! s:apply_icons() abort
   if 0 == len(s:cb_map)
     return
   endif
@@ -508,7 +508,7 @@ func! s:open_dir(d, reload) abort
     setlocal filetype=dirvish
     if curwin != winnr() | throw 'FileType autocmd changed the window' | endif
     let b:dirvish._c = b:changedtick
-    call dirvish#apply_icons()
+    call s:apply_icons()
   endif
   let s:recursive = ''
   call s:log(printf('open_dir EXIT : %d %s', bufnr('%'), a:d._dir))

--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -422,7 +422,7 @@ func! s:buf_render(dir, lastpath) abort
   endif
 endf
 
-func! s:apply_icons() abort
+func! dirvish#apply_icons() abort
   if 0 == len(s:cb_map)
     return
   endif
@@ -508,7 +508,7 @@ func! s:open_dir(d, reload) abort
     setlocal filetype=dirvish
     if curwin != winnr() | throw 'FileType autocmd changed the window' | endif
     let b:dirvish._c = b:changedtick
-    call s:apply_icons()
+    call dirvish#apply_icons()
   endif
   let s:recursive = ''
   call s:log(printf('open_dir EXIT : %d %s', bufnr('%'), a:d._dir))

--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -11,7 +11,7 @@ Because each Dirvish buffer-name is the literal directory path, you can |:cd|
 to the directory, >
   :cd %
 create a new file, >
-  :edit %/foo.txt
+  :edit %foo.txt
 |expand()| the directory path, >
   :let &titlestring = expand('%', 1)
 and use complementary plugin commands like |]f|/|[f| (unimpaired.vim).
@@ -106,7 +106,7 @@ FUNCTIONS                                                  *dirvish-functions*
     [range]. {bg} must be 0 (opens in current window) or 1 (opens in the
     "background").
 
-                                                       *dirvish#add_icon_fn()*
+                                                        *dirvish#add_icon_fn()*
 dirvish#add_icon_fn(fn)
     Registers a function {fn} to decide the "icon" for each path in a Dirvish
     buffer. Returns id for use with |dirvish#remove_icon_fn()|. If multiple
@@ -118,8 +118,8 @@ dirvish#add_icon_fn(fn)
     character (the "icon"). Example: >
         call dirvish#add_icon_fn({p -> p[-1:]=='/'?'📂':'📄'})
 <
-
-dirvish#apply_icons() 							       *dirvish#apply_icons()*
+                                                       *dirvish#apply_icons()*
+dirvish#apply_icons() 							      
 	Reapply the icons returned by the functions registered with
 	|dirvish#add_icon_fn()|.
 

--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -119,6 +119,10 @@ dirvish#add_icon_fn(fn)
         call dirvish#add_icon_fn({p -> p[-1:]=='/'?'📂':'📄'})
 <
 
+dirvish#apply_icons() 							       *dirvish#apply_icons()*
+	Reapply the icons returned by the functions registered with
+	|dirvish#add_icon_fn()|.
+
                                                     *dirvish#remove_icon_fn()*
 dirvish#remove_icon_fn(fn_id)
     Unregisters the function associated with {fn_id} returned from

--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -106,7 +106,7 @@ FUNCTIONS                                                  *dirvish-functions*
     [range]. {bg} must be 0 (opens in current window) or 1 (opens in the
     "background").
 
-                                                        *dirvish#add_icon_fn()*
+                                                       *dirvish#add_icon_fn()*
 dirvish#add_icon_fn(fn)
     Registers a function {fn} to decide the "icon" for each path in a Dirvish
     buffer. Returns id for use with |dirvish#remove_icon_fn()|. If multiple

--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -118,11 +118,6 @@ dirvish#add_icon_fn(fn)
     character (the "icon"). Example: >
         call dirvish#add_icon_fn({p -> p[-1:]=='/'?'📂':'📄'})
 <
-                                                       *dirvish#apply_icons()*
-dirvish#apply_icons() 							      
-	Reapply the icons returned by the functions registered with
-	|dirvish#add_icon_fn()|.
-
                                                     *dirvish#remove_icon_fn()*
 dirvish#remove_icon_fn(fn_id)
     Unregisters the function associated with {fn_id} returned from

--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -118,6 +118,7 @@ dirvish#add_icon_fn(fn)
     character (the "icon"). Example: >
         call dirvish#add_icon_fn({p -> p[-1:]=='/'?'📂':'📄'})
 <
+
                                                     *dirvish#remove_icon_fn()*
 dirvish#remove_icon_fn(fn_id)
     Unregisters the function associated with {fn_id} returned from


### PR DESCRIPTION
This PR doesn't change much, it just make the function `s:apply_icons()` global by changing its name `dirvish#apply_icons()`. This allows users to have better control about when icons should be applied.

An example usage of this PR is [vim-dirvish-git.lua](https://github.com/brianhuster/vim-dirvish-git.lua)

Related to [#246]