### PR TITLE
feat(icons): use virtual text if possible

### DIFF
--- a/doc/dirvish.txt
+++ b/doc/dirvish.txt
@@ -114,10 +114,12 @@ dirvish#add_icon_fn(fn)
     a given path, wins. Best practice: if you don't have anything meaningful
     to show for a given path, return empty string (or whitespace).
 
-    {fn} is any |Funcref| that takes a path (string) and returns a single
-    character (the "icon"). Example: >
+    {fn} is any |Funcref| that takes a path (string) and returns a string
+    (the "icon"). Example: >vim
         call dirvish#add_icon_fn({p -> p[-1:]=='/'?'📂':'📄'})
 <
+    Note: multi-character icons are only supported on Nvim 0.8+ or Vim 9.1+
+    with |+textprop|.
 
                                                     *dirvish#remove_icon_fn()*
 dirvish#remove_icon_fn(fn_id)


### PR DESCRIPTION
Closes #145, #253

Screenshot of vim-dirvish with Nerdfont icon
![image](https://github.com/user-attachments/assets/a2af6bad-0b17-4c75-bd2e-9c122e19a235)

Regarding #253, I don't see the bug when using virtual text (both extmark and textprop) instead of conceal for icons, so it's possibly a bug with icons. That's why I think PR can also close that issue