### PR TITLE
fix: arglist toggle and syntax when using dirvish_relative_paths

### DIFF
--- a/autoload/dirvish.vim
+++ b/autoload/dirvish.vim
@@ -115,9 +115,10 @@ func! s:set_args(args) abort
   endif
   let normalized_argv = map(argv(), 'fnamemodify(v:val, ":p")')
   for f in a:args
-    let i = index(normalized_argv, f)
+    let normalized_f = fnamemodify(f, ':p')
+    let i = index(normalized_argv, normalized_f)
     if -1 == i
-      exe '$argadd '.fnameescape(fnamemodify(f, ':p'))
+      exe '$argadd '.fnameescape(normalized_f)
     elseif 1 == len(a:args)
       exe (i+1).'argdelete'
       syntax clear DirvishArg

--- a/syntax/dirvish.vim
+++ b/syntax/dirvish.vim
@@ -14,8 +14,10 @@ endif
 
 " Define (again). Other windows (different arglists) need the old definitions.
 " Do these last, else they may be overridden (see :h syn-priority).
+let s:rel = exists('g:dirvish_relative_paths')
 for s:p in argv()
-  exe 'syntax match DirvishArg ,'.escape(fnamemodify(s:p,':p'),'[,*.^$~\').'$, contains=DirvishPathHead'
+  let s:f = s:rel ? fnamemodify(s:p, ':p:.') : fnamemodify(s:p, ':p')
+  exe 'syntax match DirvishArg ,'.escape(s:f,'[,*.^$~\').'$, contains=DirvishPathHead'
 endfor
 
 let b:current_syntax = 'dirvish'


### PR DESCRIPTION
# Description

Setting `let g:dirvish_relative_paths = 1` breaks arglist tracking and syntax highlighting.

## Steps to reproduce

1. Add `let g:dirvish_relative_paths = 1` into your vimrc, init.vim, or equivalent configuration file.
2. Edit an exsisting file `nvim myfile`
3. Open dirvish via `-`
    * Note that `myfile` is not highlighted using the `DirvishArg` highlight
4. Press `x` one or more times
    * Note that the message `arglist: N files` increases N with each press of `x` and that the syntax is not toggled

## Fix

Normalize the filepath in two code sections. During the syntax detection and when invoking `set_args`